### PR TITLE
Implement getOrFetchWithResult method in CacheStore

### DIFF
--- a/lib/src/typed_cache.dart
+++ b/lib/src/typed_cache.dart
@@ -89,9 +89,31 @@ abstract interface class TypedCache<E, D extends Object> {
     bool allowExpiredWhileRevalidating = false,
   });
 
+  /// Gets a value from cache or fetches it if missing/expired, returning
+  /// a [Result] that encapsulates success or failure.
+  ///
+  /// This is the primary method for cache-aside pattern:
+  /// 1. Try to get from cache
+  /// 2. If missing/expired, call [fetch] to get fresh data and wrap in Result
+  /// 3. Store the result with optional [ttl] and [tags]
+  ///
+  /// Parameters:
+  /// - [key]: The cache key
+  /// - [fetch]: Function that returns fresh data
+  /// - [ttl]: Optional time-to-live for cached value
+  /// - [tags]: Optional tags for grouped invalidation
+  ///
+  Future<Result<D, CacheBackendException>> getOrFetchWithResult(
+    String key, {
+    required Future<D> Function() fetch,
+    Duration? ttl,
+    Set<String> tags,
+  });
+
   /// Removes a single entry by key.
   ///
   /// This is an alias for [remove] but more explicit about invalidation intent.
+  @Deprecated('invalidate is deprecated, use remove instead')
   Future<void> invalidate(String key);
 
   /// Removes all entries with the given [tag].
@@ -120,6 +142,6 @@ abstract interface class TypedCache<E, D extends Object> {
   /// Throws [CacheBackendException] if the backend fails.
   Future<void> put(String key, D value, {Duration? ttl, Set<String> tags});
 
-  /// Removes a single entry by key (see [invalidate] for clarity).
+  /// Removes a single entry by key.
   Future<void> remove(String key);
 }

--- a/lib/src/utils/typed_result.dart
+++ b/lib/src/utils/typed_result.dart
@@ -1,0 +1,142 @@
+final class Failure<S, F> extends Result<S, F> {
+  final F error;
+  const Failure(this.error);
+}
+
+/// A lightweight implementation of the Result pattern for Clean Architecture.
+/// Uses Dart 3 sealed classes to ensure exhaustive handling.
+///
+/// [S] is the success type [Success.value].
+/// [F] is the failure type [Failure.error].
+sealed class Result<S, F> {
+  const Result();
+
+  /// Creates a Failure result
+  factory Result.failure(F failure) = Failure<S, F>;
+
+  /// Creates a Success result
+  factory Result.success(S value) = Success<S, F>;
+
+  /// Returns the error or null if success
+  F? get failureOrNull => isFailure ? (this as Failure<S, F>).error : null;
+
+  /// Returns the success value or null if failure
+  S? get getOrNull => isSuccess ? (this as Success<S, F>).value : null;
+
+  /// Checks if this is a failure
+  bool get isFailure => this is Failure<S, F>;
+
+  /// Checks if this is a success
+  bool get isSuccess => this is Success<S, F>;
+
+  /// The magic method: forces handling of both cases.
+  /// Ideal for use in Widgets/Blocs.
+  T fold<T extends Object?>({
+    required T Function(S value) onSuccess,
+    required T Function(F error) onFailure,
+  }) {
+    return switch (this) {
+      Success<S, F>(value: final S v) => onSuccess(v),
+      Failure<S, F>(error: final F e) => onFailure(e),
+    };
+  }
+
+  /// Semantic alias for [fold], maintained for readability and familiarity
+  /// with pattern matching APIs (e.g., `when` in other languages).
+  /// Especially useful in Widgets/Blocs; for new code, prefer using [fold].
+  T when<T extends Object>(
+    T Function(S value) onSuccess,
+    T Function(F error) onFailure,
+  ) => fold<T>(onSuccess: onSuccess, onFailure: onFailure);
+
+  /// Static utility to wrap dangerous calls (try-catch)
+  static Future<Result<T, Exception>> guard<T extends Object>(
+    Future<T> Function() block,
+  ) async {
+    try {
+      return Result<T, Exception>.success(await block());
+    } on Exception catch (e) {
+      return Result<T, Exception>.failure(e);
+    } catch (e) {
+      return Result<T, Exception>.failure(Exception(e.toString()));
+    }
+  }
+
+  /// Asynchronous utility to create a Result from an async function
+  /// that may throw an exception of type F.
+  /// Type F must extend Object to ensure it is not null.
+  /// Usage example:
+  /// ```dart
+  /// final result = await Result.resultAsync<MyType, MyException>(() async {
+  ///    // code that may throw MyException
+  ///  return await fetchData();
+  /// });
+  /// ```
+  static Future<Result<T, F>> resultAsync<T, F extends Object>(
+    Future<T> Function() action,
+  ) async {
+    try {
+      final T value = await action();
+      return Result<T, F>.success(value);
+    } on F catch (e) {
+      return Result<T, F>.failure(e);
+    }
+  }
+}
+
+final class Success<S, F> extends Result<S, F> {
+  final S value;
+  const Success(this.value);
+}
+
+extension ResultExtension<S, F> on Result<S, F> {
+  /// Flat maps a [Result] to a new [Result] with a different success type.
+  Result<R, F> flatMap<R extends Object>(
+    Result<R, F> Function(S value) mapper,
+  ) {
+    return fold<Result<R, F>>(
+      onSuccess: mapper,
+      onFailure: (F error) => Result<R, F>.failure(error),
+    );
+  }
+
+  /// Flat maps a [Result] to a new [Result] with a different error type.
+  Result<S, R> flatMapError<R>(Result<S, R> Function(F error) mapper) {
+    return fold(
+      onSuccess: (S value) => Result<S, R>.success(value),
+      onFailure: (F error) => mapper(error),
+    );
+  }
+
+  /// Maps a [Result] to a new [Result] with a different success type.
+  Result<R, F> map<R extends Object>(R Function(S value) mapper) {
+    return fold(
+      onSuccess: (S value) => Result<R, F>.success(mapper(value)),
+      onFailure: (F error) => Result<R, F>.failure(error),
+    );
+  }
+
+  /// Maps a [Result] to a new [Result] with a different error type.
+  Result<S, R> mapError<R>(R Function(F error) mapper) {
+    return fold(
+      onSuccess: (S value) => Result<S, R>.success(value),
+      onFailure: (F error) => Result<S, R>.failure(mapper(error)),
+    );
+  }
+
+  /// Executes a side effect function if the result is a failure.
+  Result<S, F> onFailure(void Function(F error) effect) {
+    if (this case Failure<S, F>(error: final F e)) {
+      effect(e);
+    }
+    return this;
+  }
+
+  /// Executes a side effect function if the result is a success.
+  Result<S, F> onSuccess(void Function(S value) effect) {
+    if (this case Success<S, F>(value: final S v)) {
+      effect(v);
+    }
+    return this;
+  }
+}

--- a/lib/typed_cache.dart
+++ b/lib/typed_cache.dart
@@ -50,3 +50,4 @@ export 'src/errors.dart';
 export 'src/policy/clock.dart';
 export 'src/policy/ttl_policy.dart';
 export 'src/typed_cache.dart';
+export 'src/utils/typed_result.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: typed_cache
 description: A strongly-typed, generic caching library for Dart.
-version: 0.2.1
+version: 0.3.0
 repository: https://github.com/saulogatti/typed_cache.git
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
Introduce the getOrFetchWithResult method to CacheStore for improved caching behavior. This method retrieves a cached value or fetches it if missing, encapsulating the result in a Result type for better error handling. A new Result class has been added to manage success and failure states. Update tests to cover the new functionality. Version updated to 0.3.0.